### PR TITLE
LIBIIIF-128. Updated Nginx configuration to proxy to legacy IIIF servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@
 # where <VERSION> is the Docker image version to create.
 FROM docker.lib.umd.edu/umd-web-static-files:1.0.0
 
+COPY docker_config/nginx/ /etc/nginx/
+
 COPY html /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -3,14 +3,40 @@
 Provides a Docker image configuration for serving static iiif.lib.umd.edu
 application files, including the Mirador viewer.
 
-This Docker image extends umd-web-static-files by adding these files:
+This Docker image extends umd-web-static-files by:
 
-* an "index.html" home page
-* static Mirador viewer files from
-  [https://github.com/umd-lib/mirador-static][mirador-static]
+* Adding an "index.html" home page
+
+* Adding static Mirador viewer files from
+[https://github.com/umd-lib/mirador-static][mirador-static]
+
+* Replacing the Nginx configuration with a configuration that proxies some
+URLs to legacy IIIF servers.
 
 See [umd-web-static-files][umd-web-static-files] for more information about
 using this image.
+
+**Note**: When updating the base "umd-web-static-files" Docker image version,
+be sure to update the "docker_config/nginx/conf.d/default.conf" file to reflect
+any changes.
+
+## Docker Image
+
+To build the Docker image:
+
+```
+> docker build -t docker.lib.umd.edu/iiif-static-files:<VERSION> -f Dockerfile .
+```
+
+where \<VERSION> is the version for the image.
+
+For example, to build version 1.0.0:
+
+```
+> docker build -t docker.lib.umd.edu/iiif-static-files:1.0.0 -f Dockerfile .
+```
+
+The image should then be pushed to the UMD Nexus.
 
 ## Mirador Viewer
 

--- a/docker_config/nginx/conf.d/default.conf
+++ b/docker_config/nginx/conf.d/default.conf
@@ -1,0 +1,35 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    # Rewrites URLs to use files in per-file subdirectories.
+    rewrite ^/favicon.ico$ /favicon/favicon.ico last;
+    rewrite ^/googlee5878e862cad1cec.html$ /google-file-upload/googlee5878e862cad1cec.html last;
+    rewrite ^/robots.txt$ /robots/robots.txt last;
+    rewrite ^/sitemap.xml$ /sitemap/sitemap.xml last;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    location /images {
+        # "iiif-legacy-service" is an ExternalName in the
+        # "k8s-iiif/base/iiif-static-files/service.yaml" Kubernetes
+        # configuration that points to the "legacy" IIIF server
+        # (i.e., https://iiifdev.lib.umd.edu, https://iiifstage.lib.umd.edu,
+        # etc.)
+        proxy_pass https://iiif-legacy-service/images;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Replaced the default Nginx configuration from "umd-web-static-files"
with a configuration that enables the "/images" path to be proxied
to a legacy IIIF server.

Because Nginx does not have a mechanism for using environment variables
in its configuration files (see https://serverfault.com/a/755541), and
the only workaround was to use "envsubst", which didn't seem like an
easy fit for what we're trying to do, a Kubernetes "ExternalName"
service (in the "umd-lib/k8s-iiif" repository) is used to handle the
redirect to the correct server.

There did not appear to be any way to merge a modified Nginx
configuration with the Nginx configuration from "umd-web-static-files",
so the Nginx configuration from "umd-web-static-files" is completely
replaced with the repository's own copy of the
"docker_config/nginx/conf.d/default.conf" file.

https://issues.umd.edu/browse/LIBIIIF-128