### PR TITLE
LIBIIIF-140. Remove /images proxy to iiif-legacy.

### DIFF
--- a/docker_config/nginx/conf.d/default.conf
+++ b/docker_config/nginx/conf.d/default.conf
@@ -9,25 +9,15 @@ server {
     rewrite ^/robots.txt$ /robots/robots.txt last;
     rewrite ^/sitemap.xml$ /sitemap/sitemap.xml last;
 
-    #charset koi8-r;
-    #access_log  /var/log/nginx/host.access.log  main;
-
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
     }
 
-    location /images {
-        # "iiif-legacy-service" is an ExternalName in the
-        # "k8s-iiif/base/iiif-static-files/service.yaml" Kubernetes
-        # configuration that points to the "legacy" IIIF server
-        # (i.e., https://iiifdev.lib.umd.edu, https://iiifstage.lib.umd.edu,
-        # etc.)
-        proxy_pass https://iiif-legacy-service/images;
-    }
+    # catch old (pre-Cantaloupe) image URLs
+    rewrite ^/images/(fcrepo|fedora2|static):(.*) /images/iiif/2/$1:$2 permanent;
 
     # redirect server error pages to the static page /50x.html
-    #
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;

--- a/html/index.html
+++ b/html/index.html
@@ -5,7 +5,7 @@
   <body>
     <h1>IIIF Image Server</h1>
     <ul>
-      <li><a href="images/">Loris Image Server</a></li>
+      <li><a href="images/">Image Server</a></li>
       <li><a href="manifests/">PCDM Manifests</a></li>
     </ul>
   </body>


### PR DESCRIPTION
* Renamed image server link
* Added redirect for the old /images endpoint to point to /images/iiif/2 instead

https://issues.umd.edu/browse/LIBIIIF-140