### PR TITLE
LIBIIIF-199. Replace "PCDM Manifests" link text with generic "Manifest Server".

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1,12 +1,12 @@
 <html>
   <head>
-    <title>IIIF Image Server</title>
+    <title>IIIF Services</title>
   </head>
   <body>
-    <h1>IIIF Image Server</h1>
+    <h1>IIIF Services</h1>
     <ul>
       <li><a href="images/">Image Server</a></li>
-      <li><a href="manifests/">PCDM Manifests</a></li>
+      <li><a href="manifests/">Manifest Server</a></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Also retitled the landing page from "IIIF Image Server" to "IIIF Services".

https://umd-dit.atlassian.net/browse/LIBIIIF-199