### PR TITLE
LIBIIIF-204. Removed "Click on annotations to display selection text."

### DIFF
--- a/html/viewer/1.2.0/js/site.js
+++ b/html/viewer/1.2.0/js/site.js
@@ -222,15 +222,11 @@ $(function() {
         }
 
         if (typeof options.viewType !== 'undefined') {
-          if (options.viewType === 'ImageView') {
-            $('div.sidePanel').html('<h2 style=\"color: #a40404;\">Selection Text</h2><p><a style=\"color: #006699;\" '+
-                'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p><p style=\"color: #555555;\">' +
-                'Click on annotations to display selection text.</p>');
-          } else {
-            $('div.sidePanel').html('<h2 style=\"color: #a40404;\">Selection Text</h2><p><a style=\"color: #006699;\" ' +
-                'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p><p style=\"color: #555555;\">' +
-                'Switch to the Image View and click on annotations to display selection text.</p>');
-            if (sidePanelVisible) { m.eventEmitter.publish('sidePanelVisibilityByTab', false); }
+          $('div.sidePanel').html('<p><a style=\"color: #006699;\" '+
+              'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p>'
+            );
+          if ((options.viewType !== 'ImageView') && sidePanelVisible) {
+            m.eventEmitter.publish('sidePanelVisibilityByTab', false);
           }
           // enable selection on side panel and meta data information panel
           $('div.sidePanel').mousemove(function(e){ e.stopPropagation(); });

--- a/html/viewer/1.3.0/js/site.js
+++ b/html/viewer/1.3.0/js/site.js
@@ -218,15 +218,11 @@ $(function() {
         }
 
         if (typeof options.viewType !== 'undefined') {
-          if (options.viewType === 'ImageView') {
-            $('div.sidePanel').html('<h2 style=\"color: #a40404;\">Selection Text</h2><p><a style=\"color: #006699;\" '+
-                'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p><p style=\"color: #555555;\">' +
-                'Click on annotations to display selection text.</p>');
-          } else {
-            $('div.sidePanel').html('<h2 style=\"color: #a40404;\">Selection Text</h2><p><a style=\"color: #006699;\" ' +
-                'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p><p style=\"color: #555555;\">' +
-                'Switch to the Image View and click on annotations to display selection text.</p>');
-            if (sidePanelVisible) { m.eventEmitter.publish('sidePanelVisibilityByTab', false); }
+          $('div.sidePanel').html('<p><a style=\"color: #006699;\" '+
+              'href=\"http://www.lib.umd.edu/digital/contact/digital-feedback\" target=\"_blank\">Feedback</a></p>'
+            );
+          if ((options.viewType !== 'ImageView') && sidePanelVisible) {
+            m.eventEmitter.publish('sidePanelVisibilityByTab', false);
           }
           // enable selection on side panel and meta data information panel
           $('div.sidePanel').mousemove(function(e){ e.stopPropagation(); });


### PR DESCRIPTION
Removed "Click on annotations to display selection text." text and "Selection Text" title in the Mirador viewer 1.3.0 sidebar, because there are no annotations to click, and having this message is confusing to the user.

Simiplified the logic by moving the "Feedback" link out of the `if` (since it is the same in both branches), and collapsed the remaining outer and inner `ifs` into a single `if` combined with `&&`.

https://umd-dit.atlassian.net/browse/LIBIIIF-204